### PR TITLE
Update fs-testimonial.php

### DIFF
--- a/fs-testimonial.php
+++ b/fs-testimonial.php
@@ -160,7 +160,12 @@ class FS_Testimonials {
 					$divs = [];
 					$i = 0;
 					foreach ( $testimonials as $r ) {
-						$divs[ $i ++ % 3 ] .= $this->testimonial_html( $r );
+						 $y = $i ++ % 3;
+					         if (! isset ($divs[ $y ])) {
+						    $divs[ $y ] = $this->testimonial_html( $r );
+                                                 } else {
+						 $divs[ $y ] .= $this->testimonial_html( $r );
+						 }
 					}
 
 					echo "<div>$divs[0]</div>";


### PR DESCRIPTION
Getting  
    Notice: Undefined offset: 0 in /var/www/html/wp-content/plugins/fs-testimonials/fs-testimonial.php on line 165 

This seems to be caused by appending to non existent array elements.

    $divs[ i ++ % 3 ] .= $this->testimonial_html( $r );

Solvable by checking before appending

    $y = $i ++ % 3;
    if (! isset ($divs[ $y ])) {
        $divs[ $y ] = $this->testimonial_html( $r );
     } else {
         $divs[ $y ] .= $this->testimonial_html( $r );
    }